### PR TITLE
Include Authorization header on WebSocket connection

### DIFF
--- a/src/common/ws-client.ts
+++ b/src/common/ws-client.ts
@@ -47,7 +47,10 @@ export class WsClient {
 		this.prevHost = settings.host;
 		this.prevPort = settings.port;
 
-		this.socket = new WebSocket('http://' + settings.host + ":" + settings.port + Endpoints.Ws);
+		this.socket = new WebSocket(
+			'ws://' + settings.host + ":" + settings.port + Endpoints.Ws,
+			{ headers: { Authorization: `Bearer ${settings.auth_token}` } }
+		);
 
 		this.socket.on('error', (m) => {});
 


### PR DESCRIPTION
## Summary

The upstream API server (now at github.com/pear-devs/pear-desktop after the th-ch/youtube-music rename) requires authentication on the WebSocket upgrade. The plugin currently opens the WS without an `Authorization` header, so the upgrade is rejected with HTTP 400 and the plugin enters an infinite 1-second reconnect loop.

This means none of the WebSocket-driven state ever flows through:
- Song info display never updates (relies on `PLAYER_INFO` events)
- Volume state is stale (relies on `VOLUME_CHANGED`)
- Shuffle / repeat button states don't reflect actual state (rely on `SHUFFLE_CHANGED` / `REPEAT_CHANGED`)

Fixed by including the existing `auth_token` from global settings as a Bearer token on the WS connection.

## Repro (before fix)

1. Install the plugin against a current pear-desktop / th-ch youtube-music build with the API Server plugin enabled
2. Authorize the plugin
3. Add a Song Info action to a button
4. Tail the plugin log

Result — repeating every second:
```
DEBUG Ws closed 1006 {"type":"Buffer","data":[]}
```

Verified the same request without the auth header in Insomnia returns HTTP 400 from the API server. With the header, the upgrade succeeds and messages flow.

## After fix

```
DEBUG Ws connected
DEBUG Received message {"type":"PLAYER_INFO", ...}
DEBUG Received message {"type":"POSITION_CHANGED","position":88}
```

Song info, shuffle state, and repeat state all work correctly on the deck.

## Notes

- Also changed `http://` to `ws://` in the URL string. The `ws` library accepts both, but `ws://` is correct and avoids relying on the implicit upgrade.
- Volume up/down still doesn't behave intuitively, but on investigation that's a separate issue on the API server side (POST and GET use different scales) — not addressable in this plugin. Filing separately upstream.